### PR TITLE
Jsをvue.jsに置き換え

### DIFF
--- a/app/forms/teacher/student_form.rb
+++ b/app/forms/teacher/student_form.rb
@@ -15,7 +15,6 @@ class Teacher::StudentForm
 
   def assign_attributes(params = {})
     @params = params
-    self.inputs_home_address = params[:inputs_home_address] == "1"
     self.inputs_parents_address = params[:inputs_parents_address] == "1"
     student_member.assign_attributes(student_member_params)
 

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,8 +1,0 @@
-<script>
-export default {
-  el: '#wrapper',
-  data: {
-    able: true,
-  }
-}
-</script>

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,0 +1,8 @@
+<script>
+export default {
+  el: '#wrapper',
+  data: {
+    able: true,
+  }
+}
+</script>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,3 +6,6 @@ require("channels")
 import "bootstrap";
 import "../stylesheets/application.scss";
 import '@fortawesome/fontawesome-free/js/all';
+import TurbolinksAdapter from 'vue-turbolinks'
+
+Vue.use(TurbolinksAdapter)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,4 +8,4 @@ import "../stylesheets/application.scss";
 import '@fortawesome/fontawesome-free/js/all';
 import TurbolinksAdapter from 'vue-turbolinks'
 
-Vue.use(TurbolinksAdapter)
+Turbolinks.start()

--- a/app/javascript/packs/teacher.js
+++ b/app/javascript/packs/teacher.js
@@ -1,4 +1,3 @@
-require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")

--- a/app/javascript/teacher/student_member_form.js
+++ b/app/javascript/teacher/student_member_form.js
@@ -1,22 +1,10 @@
-function toggle_home_address_fields() {
-  const checked = $("input#form_inputs_home_address").prop("checked");
-  $("fieldset#home-address-fields input").prop("disabled", !checked);
-  $("fieldset#home-address-fields select").prop("disabled", !checked);
-}
+import Vue from 'vue/dist/vue.esm'
 
-function toggle_parents_address_fields() {
-  const checked = $("input#form_inputs_parents_address").prop("checked");
-  $("fieldset#parents-address-fields input").prop("disabled", !checked);
-  $("fieldset#parents-address-fields select").prop("disabled", !checked);
-}
-
-$(document).on("ready turbolinks:load", () => {
-  toggle_home_address_fields();
-  toggle_parents_address_fields();
-  $("input#form_inputs_home_address").on("click", () => {
-    toggle_home_address_fields();
-  });
-  $("input#form_inputs_parents_address").on("click", () => {
-    toggle_parents_address_fields();
-  });
-});
+document.addEventListener('DOMContentLoaded', () => {
+  const app = new Vue({
+    el: '#wrapper',
+    data: {
+      able: true
+    }
+  })
+})

--- a/app/javascript/teacher/student_member_form.js
+++ b/app/javascript/teacher/student_member_form.js
@@ -1,6 +1,6 @@
 import Vue from 'vue/dist/vue.esm'
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbolinks:load', () => {
   const app = new Vue({
     el: '#wrapper',
     data: {

--- a/app/presenters/vue_address_form_presenter.rb
+++ b/app/presenters/vue_address_form_presenter.rb
@@ -1,0 +1,25 @@
+class VueAddressFormPresenter < FormPresenter
+  def postal_code_block(name,label_text, options={})
+    markup(:div,class: "input-block col-2") do |m|
+      m << label(name, label_text, class: "form-label")
+      m << text_field(name, class: "form-control", "v-bind:disabled"=>"!able")
+      m << error_messages_for(name)
+    end
+  end
+
+  def drop_down_list_block(name, label_text, choices, options = {})
+    markup(:div, class: "input-block col-5") do |m|
+      m << label(name,label_text, class: options[:required] ? "required" : nil, class: "form-label mt-2")
+      m << form_builder.select(name, choices, {include_blank: true}, class: "form-select mb-3", "v-bind:disabled"=>"!able")
+      m << error_messages_for(name)
+    end
+  end
+
+  def text_field_block(name, label_text, options= {})
+    markup(:div, class: "col-5") do |m|
+      m << label(name, label_text, class: options[:required] ? "required" : nil ,class: "form-label mt-2")
+      m << text_field(name, class:"form-control", "v-bind:disabled"=>"!able")
+      m << error_messages_for(name)
+    end
+  end
+end

--- a/app/views/teacher/student_members/_form.html.erb
+++ b/app/views/teacher/student_members/_form.html.erb
@@ -1,21 +1,39 @@
+<script src="https://cdn.jsdelivr.net/npm/vue@2.6.14"></script>
 <div id="student-info" class="card-body">
   <%= render "student_fields", f: f %>
 </div>
 
 <h3 class="card-header">生徒住所入力</h3>
 <div id="student-address" class="card-body">
-  <%= f.check_box :inputs_home_address %>
-  <%= f.label :inputs_home_address, "自宅住所を入力する" %>
   <fieldset id="home-address-fields">
   <%= render "home_address_fields", f: f %>
+  <input type="text" v-bind:disabled="!able">
   </fieldset>
 </div>
 
 <h3 class="card-header">保護者住所入力</h3>
 <div id="parents-address" class="card-body">
-  <%= f.check_box :inputs_parents_address %>
+  <%= f.check_box :inputs_parents_address, "v-model" => "able" %>
   <%= f.label :inputs_parents_address, "保護者住所を入力する(別住所の場合のみ入力してください)" %>
   <fieldset id="parents-address-fields">
   <%= render "parents_address_fields", f: f %>
   </fieldset>
 </div>
+<script type="text/javascript">
+  var app = new Vue({
+  el: '#wrapper',
+  data: {
+    able: true,
+    toggleHomeAddressFields: true
+  },
+  watch: {
+    toggleHomeAddressFields(){
+      if (able) {
+        return false;
+      } else {
+        return true;
+      }
+    }
+  }
+})
+</script>

--- a/app/views/teacher/student_members/_form.html.erb
+++ b/app/views/teacher/student_members/_form.html.erb
@@ -4,6 +4,7 @@
 
 <h3 class="card-header">生徒住所入力</h3>
 <div id="student-address" class="card-body">
+  <%= f.label :inputs_home_address, "自宅住所を入力する" %>
   <fieldset id="home-address-fields">
     <%= render "home_address_fields", f: f %>
   </fieldset>

--- a/app/views/teacher/student_members/_form.html.erb
+++ b/app/views/teacher/student_members/_form.html.erb
@@ -1,4 +1,3 @@
-<script src="https://cdn.jsdelivr.net/npm/vue@2.6.14"></script>
 <div id="student-info" class="card-body">
   <%= render "student_fields", f: f %>
 </div>
@@ -6,8 +5,7 @@
 <h3 class="card-header">生徒住所入力</h3>
 <div id="student-address" class="card-body">
   <fieldset id="home-address-fields">
-  <%= render "home_address_fields", f: f %>
-  <input type="text" v-bind:disabled="!able">
+    <%= render "home_address_fields", f: f %>
   </fieldset>
 </div>
 
@@ -16,24 +14,6 @@
   <%= f.check_box :inputs_parents_address, "v-model" => "able" %>
   <%= f.label :inputs_parents_address, "保護者住所を入力する(別住所の場合のみ入力してください)" %>
   <fieldset id="parents-address-fields">
-  <%= render "parents_address_fields", f: f %>
+    <%= render "parents_address_fields", f: f %>
   </fieldset>
 </div>
-<script type="text/javascript">
-  var app = new Vue({
-  el: '#wrapper',
-  data: {
-    able: true,
-    toggleHomeAddressFields: true
-  },
-  watch: {
-    toggleHomeAddressFields(){
-      if (able) {
-        return false;
-      } else {
-        return true;
-      }
-    }
-  }
-})
-</script>

--- a/app/views/teacher/student_members/_parents_address_fields.html.erb
+++ b/app/views/teacher/student_members/_parents_address_fields.html.erb
@@ -1,6 +1,6 @@
 <%= f.fields_for :parents_address, f.object.student_member.parents_address do |ff| %>
 
-<% p = AddressFormPresenter.new(ff,self) %>
+<% p = VueAddressFormPresenter.new(ff,self) %>
 
 <%= p.postal_code_block(:postal_code, "郵便番号") %>
 <%= p.drop_down_list_block(:prefecture, "都道府県", StudentMemberAddress::PREFECTURE_NAMES) %>

--- a/config/webpack/custom.js
+++ b/config/webpack/custom.js
@@ -1,0 +1,7 @@
+module.exports = {
+  resolve: {
+    alias: {
+      'vue$': 'vue/dist/vue.esm.js'
+    }
+  }
+}

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -11,4 +11,6 @@ environment.plugins.prepend("Provide",
 )
 environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
 environment.loaders.prepend('vue', vue)
+const customConfig = require('./custom')
+environment.config.merge(customConfig)
 module.exports = environment

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -34,6 +34,7 @@ default: &default
     - .woff2
 
   extensions:
+    - .vue
     - .mjs
     - .js
     - .sass

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "rails-erb-loader": "^5.5.2",
     "turbolinks": "^5.2.0",
     "vue": "^2.6.14",
-    "vue-loader": "^15.9.7",
+    "vue-loader": "^15.9.8",
     "vue-template-compiler": "^2.6.14",
     "vue-turbolinks": "^2.2.2",
     "vuetify": "^2.5.5"

--- a/spec/features/teacher/student_member_management_spec.rb
+++ b/spec/features/teacher/student_member_management_spec.rb
@@ -31,7 +31,6 @@ feature "教職員による生徒管理" do
       fill_in "入学日", with: "2018-4-23"
       fill_in "卒業予定日", with: "2021-3-31"
     end
-    check "form[inputs_home_address]"
 
     within("#student-address") do
       fill_in "郵便番号", with: "1111111"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7709,7 +7709,7 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
-vue-loader@^15.9.7:
+vue-loader@^15.9.8:
   version "15.9.8"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.8.tgz#4b0f602afaf66a996be1e534fb9609dc4ab10e61"
   integrity sha512-GwSkxPrihfLR69/dSV3+5CdMQ0D+jXg8Ma1S4nQXKJAznYFX14vHdc/NetQc34Dw+rBbIJyP7JOuVb9Fhprvog==


### PR DESCRIPTION
### WHAT
生徒登録、編集のJsをVueのテンプレート構文に置き換えた。
それに伴いVueを完全ビルドになるよう設定変更し、テストコードも変更した。
### WHY
新しい技術を適用したかったのと、jQueryよりもコードが短く済むため。