### PR TITLE
見難い、分かり辛い表示の修正

### DIFF
--- a/app/presenters/board_message_presenter.rb
+++ b/app/presenters/board_message_presenter.rb
@@ -4,4 +4,8 @@ class BoardMessagePresenter < ModelPresenter
   def contributor
     object.teacher_member.family_name
   end
+
+  def posted_at
+    "投稿日 " + object.created_at.strftime('%Y/%m/%d')
+  end
 end

--- a/app/views/student/my_questions/_my_question.html.erb
+++ b/app/views/student/my_questions/_my_question.html.erb
@@ -1,11 +1,12 @@
+<% p = QuestionPresenter.new(my_question,self)  %>
 <div class="row d-flex justify-content-center">
   <div class="card d-flex mb-4 col-10">
     <%= link_to [ :student, my_question] do %>
     <div class="card-body">
-      <h6 class="card-subtitle my-2 text-muted"><%= my_question.book.book_name %></h6>
+      <h6 class="card-subtitle my-2 text-muted"><%= p.book_name %></h6>
       <h5><%= my_question.title %></h5>
       <p class="card-text"><%= safe_join(my_question.body.split("\n"), tag(:br)) %></p>
-      <h6 class="card-subtitle my-2 text-muted"><%= my_question.created_at.strftime('%Y/%m/%d') %></h6>
+      <h6 class="card-subtitle my-2 text-muted"><%= p.posted_at %></h6>
     </div>
     <% end %>
   </div>

--- a/app/views/student/questions/show.html.erb
+++ b/app/views/student/questions/show.html.erb
@@ -1,10 +1,11 @@
+<% p = QuestionPresenter.new(@question,self) %>
 <div class="row d-flex justify-content-center">
   <div class="card d-flex mb-4 col-10">
     <div class="card-body">
+      <h6 class="card-subtitle my-2 text-muted"><%= p.book_name %></h6>
       <h5><%= @question.title %></h5>
-      <h6 class="card-subtitle my-2 text-muted"><%= @question.book.book_name %></h6>
       <p class="card-text"><%= safe_join(@question.body.split("\n"), tag(:br)) %></p>
-      <h6 class="card-subtitle my-2 text-muted"><%= @question.created_at.strftime('%Y/%m/%d') %></h6>
+      <h6 class="card-subtitle my-2 text-muted"><%= p.posted_at %></h6>
       <% if @question.closed? %>
         <p class="btn btn-outline-danger btn-block mx-auto disabled">
           この質問への回答コメントは締め切られています。

--- a/app/views/student/shared/_board_message.html.erb
+++ b/app/views/student/shared/_board_message.html.erb
@@ -3,8 +3,9 @@
   <div class="card d-flex flex-column mb-2 justify-content-center col-10" >
     <div class="card-body">
       <h5><%= p.subject %></h5>
-      <h6 class="card-subtitle my-2 text-muted"><%= p.contributor %></h6>
       <p class="card-text"><%= safe_join(p.body.split("\n"), tag(:br)) %></p>
+      <h6 class="card-subtitle my-2 text-muted"><%= p.contributor %></h6>
+      <div class="col"><%= p.posted_at %></div>
       <span class="badge bg-secondary"><%= p.tag %></span>
     </div>
   </div>

--- a/app/views/teacher/board_messages/_form.html.erb
+++ b/app/views/teacher/board_messages/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= p.text_field_block(:subject, "題名", class: "form-control") %>
 
-<%= p.text_area_block(:body, "本文", class: "form-control")%>
+<%= p.text_area_block(:body, "本文", class: "form-control", rows: "10")%>
 
 <div class="my-3 col-5">
   <%= p.drop_down_list_block(:tag, "文理",BoardMessage::BOARD_TAGS, class: "form-select form-select-sm") %>

--- a/app/views/teacher/questions/_closed_question.html.erb
+++ b/app/views/teacher/questions/_closed_question.html.erb
@@ -3,7 +3,7 @@
 <% if closed_question.closed %>
   <div class=" card col-lg-5 my-4" style="height: 18rem">
     <div class="card-body">
-      <p><%= p.book_name %></p>
+      <h6 class="card-subtitle my-2 text-muted"><%= p.book_name %></h6>
       <h5 class="title-overflow my-3"><%= p.title  %></h5>
       <p class="text-overflow card-text overflow-hidden"><%= p.body %></p>
     </div>

--- a/app/views/teacher/questions/_open_question.html.erb
+++ b/app/views/teacher/questions/_open_question.html.erb
@@ -3,7 +3,7 @@
 <% unless open_question.closed %>
   <div class=" card col-lg-5 my-4" style="height: 18rem">
     <div class="card-body">
-      <p><%= p.book_name %></p>
+      <h6 class="card-subtitle my-2 text-muted"><%= p.book_name %></h6>
       <h5 class="title-overflow my-3"><%= p.title  %></h5>
       <p class="text-overflow card-text overflow-hidden"><%= p.body %></p>
     </div>

--- a/app/views/teacher/questions/show.html.erb
+++ b/app/views/teacher/questions/show.html.erb
@@ -2,8 +2,8 @@
 <div class="row justify-content-center">
   <div class="card col-8">
     <div class="card-body">
+      <h6 class="card-subtitle my-2 text-muted"><%= p.book_name %></h6>
       <h5><%= p.title %></h5>
-      <small><%= p.book_name %></small>
       <p class="card-text"><%= safe_join(p.body.split("\n"), tag(:br)) %></p>
       <div class="row d-flex mx-2 my-2 justify-content-end">
         <p ><%= p.posted_by %></p>

--- a/app/views/teacher/shared/_board_message.html.erb
+++ b/app/views/teacher/shared/_board_message.html.erb
@@ -3,8 +3,9 @@
   <div class="card d-flex flex-column mb-2 col-lg-10 justify-content-center" >
     <div class="card-body">
       <h5><%= p.subject %></h5>
-      <h6 class="card-subtitle my-2 text-muted"><%= p.contributor %></h6>
       <p class="card-text"><%= safe_join(p.body.split("\n"), tag(:br)) %></p>
+      <h6 class="card-subtitle my-2 text-muted"><%= p.contributor %></h6>
+      <div class="card-subtitle my-2 text-muted"><%= p.posted_at %></div>
       <span class="badge bg-secondary"><%= p.tag %></span>
       <%# ログイン中のユーザーと投稿したユーザーが同じならば"編集"及び""削除"アイコンを表示させる。 %>
       <% if current_teacher_member %>


### PR DESCRIPTION
### WHAT
質問掲示板における、書籍名、タイトル、本文の順番、文字サイズがバラバラなのを統一した。
プレゼンターを新たに適用し、viewファイルの記述量を減らした。
textareaの高さがおかしいところを修正した。